### PR TITLE
feat: +seeders & faker downgrade & post model fix

### DIFF
--- a/models/post.js
+++ b/models/post.js
@@ -13,7 +13,10 @@ module.exports = (sequelize, DataTypes) => {
   }
   Post.init({
     title: DataTypes.STRING,
-    category: DataTypes.STRING,
+    category: {
+      type: DataTypes.ENUM('百岳', '郊山', '海外'),
+      allowNull: false
+    },
     description: DataTypes.TEXT,
     image: DataTypes.STRING,
     difficulty: DataTypes.STRING,

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "express": "^4.17.1",
         "express-handlebars": "^4.0.4",
         "express-session": "^1.17.1",
-        "faker": "^6.6.6",
+        "faker": "^4.1.0",
         "fast-xml-parser": "^4.2.6",
         "imgur": "^2.3.0",
         "jsonwebtoken": "^9.0.1",
@@ -1763,9 +1763,9 @@
       "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
     },
     "node_modules/faker": {
-      "version": "6.6.6",
-      "resolved": "https://registry.npmjs.org/faker/-/faker-6.6.6.tgz",
-      "integrity": "sha512-9tCqYEDHI5RYFQigXFwF1hnCwcWCOJl/hmll0lr5D2Ljjb0o4wphb69wikeJDz5qCEzXCoPvG6ss5SDP6IfOdg=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
+      "integrity": "sha512-ILKg69P6y/D8/wSmDXw35Ly0re8QzQ8pMfBCflsGiZG2ZjMUNLYNexA6lz5pkmJlepVdsiDFUxYAzPQ9/+iGLA=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -5712,9 +5712,9 @@
       }
     },
     "faker": {
-      "version": "6.6.6",
-      "resolved": "https://registry.npmjs.org/faker/-/faker-6.6.6.tgz",
-      "integrity": "sha512-9tCqYEDHI5RYFQigXFwF1hnCwcWCOJl/hmll0lr5D2Ljjb0o4wphb69wikeJDz5qCEzXCoPvG6ss5SDP6IfOdg=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
+      "integrity": "sha512-ILKg69P6y/D8/wSmDXw35Ly0re8QzQ8pMfBCflsGiZG2ZjMUNLYNexA6lz5pkmJlepVdsiDFUxYAzPQ9/+iGLA=="
     },
     "fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "express": "^4.17.1",
     "express-handlebars": "^4.0.4",
     "express-session": "^1.17.1",
-    "faker": "^6.6.6",
+    "faker": "^4.1.0",
     "fast-xml-parser": "^4.2.6",
     "imgur": "^2.3.0",
     "jsonwebtoken": "^9.0.1",

--- a/seeders/20230726080134-user-seeds.js
+++ b/seeders/20230726080134-user-seeds.js
@@ -1,0 +1,65 @@
+'use strict'
+
+const bcrypt = require('bcryptjs')
+const faker = require('faker')
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const admin = {
+      // 一組admin
+      name: 'root',
+      email: 'root@example.com',
+      password: await bcrypt.hash('1234', 10),
+      avatar: `https://i.pravatar.cc/300?img=${Math.floor(Math.random() * 100)}`,
+      introduction: "I'm admin.",
+      role: 'admin',
+      isSuspended: false,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    }
+
+    const users = []
+    // 5位一般使用者
+    for (let i = 0; i < 5; i++) {
+      const maxLength = 150
+      const randomText = faker.lorem.text(maxLength)
+      const user = {
+        name: `user${i + 1}`,
+        email: `user${i + 1}@example.com`,
+        password: await bcrypt.hash('12345678', 10),
+        avatar: `https://i.pravatar.cc/300?img=${Math.floor(Math.random() * 100)}`,
+        introduction: randomText,
+        role: 'user',
+        isSuspended: false,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }
+      users.push(user)
+    }
+
+    const ghostUsers = []
+    // 25位幽靈使用者
+    for (let i = 0; i < 25; i++) {
+      const ghostUser = {
+        name: faker.name.findName(),
+        email: faker.internet.email(),
+        password: await bcrypt.hash('12345678', 10),
+        avatar: `https://i.pravatar.cc/300?img=${Math.floor(Math.random() * 100)}`,
+        introduction: faker.lorem.text(160),
+        role: 'user',
+        isSuspended: false,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }
+      ghostUsers.push(ghostUser)
+    }
+
+    await queryInterface.bulkInsert('Users', [admin])
+    await queryInterface.bulkInsert('Users', users)
+    await queryInterface.bulkInsert('Users', ghostUsers)
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('Users', {})
+  }
+}

--- a/seeders/20230726120612-add-generalUsers-posts.js
+++ b/seeders/20230726120612-add-generalUsers-posts.js
@@ -1,0 +1,58 @@
+'use strict'
+
+const faker = require('faker')
+const { User, Sequelize } = require('../models')
+const Op = Sequelize.Op
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    // 創建五篇心得貼文並隨機指派給一般(非幽靈)使用者
+    const posts = []
+    const categories = ['百岳', '郊山', '海外']
+    const generalUsers = await User.findAll({
+      where: {
+        name: {
+          [Op.like]: '%user%'
+        }
+      }
+    })
+    const assignedUserIds = []
+
+    for (let i = 0; i < 5; i++) {
+      const randomCategory = categories[Math.floor(Math.random() * categories.length)]
+      const randomDifficulty = Math.floor(Math.random() * 5) + 1
+      const randomRecommend = Math.floor(Math.random() * 5) + 1
+      function getRandomUserId () {
+        const randomUserIndex = Math.floor(Math.random() * generalUsers.length)
+        const randomUserId = generalUsers[randomUserIndex].id
+
+        if (!assignedUserIds.includes(randomUserId)) {
+          assignedUserIds.push(randomUserId)
+          return randomUserId
+        } else {
+          return getRandomUserId()
+        }
+      }
+
+      const post = {
+        title: `Post ${i + 1}`,
+        category: randomCategory,
+        description: faker.lorem.paragraph(),
+        image: `https://loremflickr.com/640/480/mountain/?lock=${Math.random() * 100}`,
+        difficulty: randomDifficulty,
+        recommend: randomRecommend,
+        inProgress: false,
+        UserId: getRandomUserId(),
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }
+      posts.push(post)
+    }
+
+    await queryInterface.bulkInsert('Posts', posts)
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('Posts', {})
+  }
+}

--- a/seeders/20230727035057-add-generalUsers-postFavorites.js
+++ b/seeders/20230727035057-add-generalUsers-postFavorites.js
@@ -1,0 +1,61 @@
+'use strict'
+
+const { User, Post, Sequelize } = require('../models')
+const Op = Sequelize.Op
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const favorites = []
+    const generalUsers = await User.findAll({
+      where: {
+        name: {
+          [Op.like]: '%user%'
+        }
+      }
+    })
+    const assignedUserIds = []
+    const currentPosts = await Post.findAll()
+    const assignedPostIds = []
+
+    for (let i = 0; i < 5; i++) {
+      function getRandomUserId () {
+        const randomUserIndex = Math.floor(Math.random() * generalUsers.length)
+        const randomUserId = generalUsers[randomUserIndex].id
+
+        if (!assignedUserIds.includes(randomUserId)) {
+          assignedUserIds.push(randomUserId)
+          return randomUserId
+        } else {
+          return getRandomUserId()
+        }
+      }
+
+      function getRandomPostId () {
+        const randomPostIndex = Math.floor(Math.random() * currentPosts.length)
+        const randomPostId = currentPosts[randomPostIndex].id
+
+        if (!assignedPostIds.includes(randomPostId)) {
+          assignedPostIds.push(randomPostId)
+          return randomPostId
+        } else {
+          return getRandomPostId()
+        }
+      }
+
+      const favorite = {
+        UserId: getRandomUserId(),
+        PostId: getRandomPostId(),
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }
+      favorites.push(favorite)
+    }
+
+    await queryInterface.bulkInsert('Favorites', favorites, {})
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('Favorites', {})
+  }
+}

--- a/seeders/20230727040749-add-generalUsers-followship.js
+++ b/seeders/20230727040749-add-generalUsers-followship.js
@@ -1,0 +1,52 @@
+'use strict'
+
+const { User, Sequelize } = require('../models')
+const Op = Sequelize.Op
+
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    const followshipMap = new Map()
+    const usedFollowingIds = new Set()
+    const generalUsers = await User.findAll({
+      where: {
+        name: {
+          [Op.like]: '%user%'
+        }
+      }
+    })
+
+    function getFollowingId (generalUsers, followerId, usedFollowingIds) {
+      let followingId = null
+      while (followingId === null || followingId === followerId || usedFollowingIds.has(followingId)) {
+        const randomIndex = Math.floor(Math.random() * generalUsers.length)
+        followingId = generalUsers[randomIndex].id
+      }
+      return followingId
+    }
+
+    // 創造五筆一般使用者之間的followship
+    for (let i = 0; i < generalUsers.length; i++) {
+      const followerId = generalUsers[i].id
+      const followingId = getFollowingId(generalUsers, followerId, usedFollowingIds)
+
+      usedFollowingIds.add(followingId)
+
+      if (followerId && followingId) {
+        followshipMap.set(followerId, followingId)
+      }
+    }
+
+    const followships = Array.from(followshipMap, ([followerId, followingId]) => ({
+      followerId,
+      followingId,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    }))
+
+    await queryInterface.bulkInsert('Followships', followships, {})
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('Followships', {})
+  }
+}


### PR DESCRIPTION
1. 新增user seeder, 含1位admin、5位一般user、25位幽靈使用者
2. 新增fellowship seeder, 讓5位一般user至少都有1筆追蹤及被追蹤
3. 新增post seeder, 讓5位一般user至少都有1篇心得文
4. 新增favorite seeder, 讓5位一般user至少都收藏1篇心得文
5. Faker使用上會有衝突，先降版本（v6->v4，和twitter專案同）
6. Post model 新增上user story提到的category分類限制('百岳', '郊山', '海外')

