### PR TITLE
fix: correcting error arising after post deletion

### DIFF
--- a/services/post-services.js
+++ b/services/post-services.js
@@ -1,7 +1,7 @@
 const sequelize = require('sequelize')
 const { User, Post, Like, Favorite, Report } = require('../models')
 const { imgurFileHandler } = require('../helpers/file-heplers')
-const { Op } = require('sequelize')
+const { Sequelize, Op } = require('sequelize')
 
 const postServices = {
   getPost: async (req, cb) => {
@@ -158,7 +158,7 @@ const postServices = {
           'id',
           'title',
           'category',
-          'description',
+          [sequelize.fn('SUBSTRING', Sequelize.col('description'), 1, 200), 'description'],
           'image',
           'difficulty',
           'recommend',
@@ -197,10 +197,6 @@ const postServices = {
         const postJson = post.toJSON()
         postJson.isFavorite = Boolean(postJson.isFavorite)
         postJson.isLike = Boolean(postJson.isLike)
-        const description = postJson.description
-        if (description.length > 200) {
-          postJson.description = description.slice(0, 200)
-        }
         return postJson
       })
       cb(null, allPostsData)

--- a/services/user-services.js
+++ b/services/user-services.js
@@ -3,6 +3,7 @@ const bcrypt = require('bcryptjs')
 const jwt = require('jsonwebtoken')
 const { imgurFileHandler } = require('../helpers/file-heplers')
 const { User, Post, Favorite, Followship, Notification, Trail } = require('../models')
+const { Sequelize } = require('sequelize')
 
 const userServices = {
   signIn: async (req, cb) => {
@@ -63,7 +64,7 @@ const userServices = {
         attributes: [
           'id',
           'title',
-          'description',
+          [sequelize.fn('SUBSTRING', Sequelize.col('description'), 1, 200), 'description'],
           'image',
           'difficulty',
           'userId',
@@ -282,7 +283,7 @@ const userServices = {
             attributes: [
               'id',
               'title',
-              'description',
+              [sequelize.fn('SUBSTRING', Sequelize.col('description'), 1, 200), 'description'],
               'image',
               'userId',
               'createdAt',
@@ -299,14 +300,11 @@ const userServices = {
       if (favorite.length === 0) {
         cb(null, { message: 'No favorite posts found.' })
       }
-      const favoritePost = favorite.map(post => {
+      const favoriteData = favorite.map(post => {
         const postJson = post.toJSON()
-        const description = postJson.Post.description
-        if (description.length > 200) {
-          postJson.Post.description = description.slice(0, 200)
-        }
         return postJson
       })
+      const favoritePost = favoriteData.filter(post => post.Post !== null)
       cb(null, { favoritePost })
     } catch (err) {
       cb(err)


### PR DESCRIPTION
修正 當post被刪除時，getUserFavoritePost會產生錯誤
修改 description限制長度的寫法，改成直接在撈資料時就限制長度

post被刪除但favorite清單裡仍然有postId，這時候撈取post資料只會撈到null
getUserFavoritePost會在撈資料後檢查description長度，但如果post被刪除就會變成在null裡找description所以會報錯

測試方式 
隨便favorite一個post，然後刪除該post，最後使用getUserFavoritePost
